### PR TITLE
Make port configurable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,6 +14,6 @@ config :gateway, ecto_repos: [Gateway.DB.Repo]
 config :logger, level: :warn
 
 config :gateway, :http,
-  port: 4000
+  port: { :system, "GATEWAY_PORT", 4000 }
 
 import_config "#{Mix.env}.exs"

--- a/lib/gateway.ex
+++ b/lib/gateway.ex
@@ -7,7 +7,7 @@ defmodule Gateway do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    http_config = Application.get_env(:gateway, :http)
+    http_config = Confex.get_map(:gateway, :http)
 
     children = [
       worker(Gateway.DB.Repo, []),

--- a/mix.exs
+++ b/mix.exs
@@ -54,6 +54,7 @@ defmodule Gateway.Mixfile do
      {:cowboy, ">= 0.0.0"},
      {:postgrex, ">= 0.0.0"},
      {:ecto, ">= 2.1.0-rc.2"},
+     {:confex, ">= 0.0.0"},
      {:dogma, "> 0.1.0", only: [:dev, :test]},
      {:poison, "~> 2.0", only: [:dev, :test]},
      {:benchfella, "~> 0.3", only: [:dev, :test]},


### PR DESCRIPTION
Later we can probably follow common approach in Elixir, where port is specified in a format suggesting a fallback to system ENV, see [ex_aws](https://github.com/CargoSense/ex_aws/commit/866305011ddde516346b57b67d91203a6a66b9b9#diff-04c6e90faac2675aa89e2176d2eec7d8R105).
