### PR TITLE
Remove stale code

### DIFF
--- a/lib/gateway/router.ex
+++ b/lib/gateway/router.ex
@@ -4,10 +4,6 @@ defmodule Gateway.Router do
   """
   use Plug.Router
 
-  plug Plug.Parsers, parsers: [:json],
-                     pass:  ["application/json"],
-                     json_decoder: Poison
-
   plug :match
   plug :dispatch
 


### PR DESCRIPTION
It has no effect, unless we write get/post macros directly in this module.

All actual "meat" modules have to include this chunk (or this chunk could be later extracted into a module of its own, and used in all "meat modules").
