### PR TITLE
Turn off excessive logging in statsd for tests

### DIFF
--- a/bin/ci/init-statsd.sh
+++ b/bin/ci/init-statsd.sh
@@ -4,5 +4,5 @@ apt-get install -y nodejs
 apt-get install -y git
 git clone https://github.com/etsy/statsd.git
 cd statsd
-echo '{port: 8125, mgmt_port: 8126, backends: ["./backends/console"]}' > config.js
+echo '{port: 8125, mgmt_port: 8126}' > config.js
 nodejs stats.js config.js &


### PR DESCRIPTION
Can be turned on locally for debuggging purposes any time.