### PR TITLE
Fix monitoring test

### DIFF
--- a/test/unit/plugins/monitoring_test.exs
+++ b/test/unit/plugins/monitoring_test.exs
@@ -1,6 +1,6 @@
 defmodule Gateway.Plugins.MonitoringTest do
   @moduledoc false
-  use Gateway.UnitCase
+  use Gateway.UnitCase, async: true
 
   @apis "apis"
 


### PR DESCRIPTION
В тесте мы читаем данные из statsd по TCP:

* данные = длинная строка
* читаем = пишем в tcp сокет строчку-запрос, и один раз ждем ответа из сокета (делаем так в каждом ассерте).

TCP пакет за один раз может нести **1460 байт**.

Когда:

* мы гоним тест в одиночку на свеже-запущенном statds, из TCP к нам приходит несколько десятков байт, все умещается в один пакет, мы этот пакет читаем, в нем есть что нам нужно, тест проходит,
* мы гоним много тестов, statsd шлет нам кучу байт, которые не умещаются в один пакет. **Но тест читает только один пакет**. Поэтому если там нету подстроки на которой делается ассерт – **тест падает**.

Чтоб пофиксить тест, надо было читать рекурсивно до тех пор пока не закроется сокет (т.е. при очередном чтении возвращается `{:error, :closed}`. Но statsd не закрывает сокет, он продолжает жить и слушать на этом сокете. Вместо этого statds чтобы сообщить клиенту "на твой запрос – у меня все", statsd шлет строку `END/n/n`.

Значит фикс такой: читаем из сокета рекурсивно и складываем ответы до тех пор, пока не наткнулись на `END/n/n`. Где-то в этой длинной строке, которую мы насобирали, найдется подстрока на которой мы ассертим.