### PR TITLE
Ensure matching priority is in :ets key

### DIFF
--- a/lib/annon_api/configuration/cache_adapters/ets.ex
+++ b/lib/annon_api/configuration/cache_adapters/ets.ex
@@ -41,7 +41,7 @@ defmodule Annon.Configuration.CacheAdapters.ETS do
     table_name = Keyword.fetch!(opts, :cache_space)
 
     objects = Enum.map(API.dump_apis(), fn api ->
-      {{:api, api.id}, api, compile_host_regex(api.request.host), compile_path_regex(api.request.path)}
+      {{-api.matching_priority, :api, api.id}, api, compile_host_regex(api.request.host), compile_path_regex(api.request.path)}
     end)
 
     case objects do

--- a/lib/annon_api/configuration/cache_adapters/ets.ex
+++ b/lib/annon_api/configuration/cache_adapters/ets.ex
@@ -41,7 +41,8 @@ defmodule Annon.Configuration.CacheAdapters.ETS do
     table_name = Keyword.fetch!(opts, :cache_space)
 
     objects = Enum.map(API.dump_apis(), fn api ->
-      {{-api.matching_priority, :api, api.id}, api, compile_host_regex(api.request.host), compile_path_regex(api.request.path)}
+      priority = -api.matching_priority
+      {{priority, :api, api.id}, api, compile_host_regex(api.request.host), compile_path_regex(api.request.path)}
     end)
 
     case objects do


### PR DESCRIPTION
Fix the [build](https://travis-ci.org/Nebo15/annon.api/builds/236098179).

Before:
```elixir
iex(1)> for {_, api, _, _} <- :ets.tab2list(:configuration), do: IO.puts api.inserted_at
2017-05-07 22:59:40.703795Z
2017-05-24 11:51:44.956792Z
2017-05-24 09:28:34.235263Z
2017-05-10 16:48:00.736411Z
2017-05-11 12:32:50.745892Z
2017-05-15 13:59:01.783186Z
2017-05-11 12:09:26.882815Z
2017-05-10 08:39:57.107934Z
2017-05-11 11:53:21.318624Z
2017-05-25 17:08:25.963739Z
2017-05-17 11:49:41.553655Z
2017-05-12 14:10:39.957690Z
2017-05-11 10:12:04.932357Z
2017-05-11 12:09:25.737372Z
2017-05-11 12:30:58.235430Z
2017-05-11 12:08:02.986755Z
2017-05-18 12:36:40.517500Z
2017-05-25 17:08:16.817616Z
2017-05-07 23:23:18.283755Z
[:ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok,
 :ok, :ok, :ok]
iex(2)>
```

After:
```elixir
iex(1)> for {_, api, _, _} <- :ets.tab2list(:configuration), do: IO.puts api.inserted_at
2017-05-07 22:59:40.703795Z
2017-05-07 23:23:18.283755Z
2017-05-10 08:39:57.107934Z
2017-05-10 16:48:00.736411Z
2017-05-11 10:12:04.932357Z
2017-05-11 11:53:21.318624Z
2017-05-11 12:30:58.235430Z
2017-05-11 12:09:25.737372Z
2017-05-11 12:32:50.745892Z
2017-05-11 12:09:26.882815Z
2017-05-11 12:08:02.986755Z
2017-05-12 14:10:39.957690Z
2017-05-15 13:59:01.783186Z
2017-05-17 11:49:41.553655Z
2017-05-18 12:36:40.517500Z
2017-05-24 09:28:34.235263Z
2017-05-24 11:51:44.956792Z
2017-05-25 17:08:16.817616Z
2017-05-25 17:08:25.963739Z
[:ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok, :ok,
 :ok, :ok, :ok]
iex(2)>
```